### PR TITLE
Add test for detail page and move filter logic to server

### DIFF
--- a/public/renderScreenings.js
+++ b/public/renderScreenings.js
@@ -1,28 +1,19 @@
 async function fetchScreenings() {
   const id = window.location.pathname;
-  const response = await fetch(`/api/screenings/screenings-details-page${id}`);
+  const response = await fetch(`/api/screenings-details-page${id}`);
   const payload = await response.json();
   return payload;
-}
-
-function dateHasPassed(date, time) {
-  const hoursAndMinutes = time.split(":");
-  return (
-    date.setHours(hoursAndMinutes[0], hoursAndMinutes[1], 0, 0) <= Date.now()
-  );
 }
 
 const screeningTitle = document.querySelector("#screenings__title");
 screeningTitle.innerText = "Kommande visningar för denna film";
 const screeningsContent = document.querySelector("#screenings__content");
 fetchScreenings().then((payload) => {
-  payload.data.forEach((element) => {
+  payload.forEach((element) => {
     const startTime = element.attributes.start_time.slice(0, -8);
     const startTimes = startTime.split("T");
-    if (!dateHasPassed(new Date(startTimes[0]), startTimes[1])) {
-      const screeningsListItem = document.createElement("li");
-      screeningsListItem.innerText = `${startTimes[0]} ${startTimes[1]} - Salong: ${element.attributes.room}`;
-      screeningsContent.appendChild(screeningsListItem);
-    }
+    const screeningsListItem = document.createElement("li");
+    screeningsListItem.innerText = `${startTimes[0]} ${startTimes[1]} - Salong: ${element.attributes.room}`;
+    screeningsContent.appendChild(screeningsListItem);
   });
 });

--- a/routes/screeningmovies.js
+++ b/routes/screeningmovies.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { frontpageScreening } from '../utils/screeningUtils.js';
+import { frontpageScreening, movieScreening } from '../utils/screeningUtils.js';
 import cmsAdapter from '../src/cmsAdapt.js';
 const screeningRouter = express.Router();
 
@@ -21,9 +21,8 @@ screeningRouter.get('/coming-screenings', async (req, res) => {
 
 })
 
-screeningRouter.get('/screenings/screenings-details-page/movies/:id', async (req, res) => {
-    const response = await fetch(`https://plankton-app-xhkom.ondigitalocean.app/api/screenings?filters[movie]=${req.params.id}`);
-    const payload = await response.json();
+screeningRouter.get('/screenings-details-page/movies/:id', async (req, res) => {
+    const payload = await movieScreening(req.params.id, cmsAdapter);
     res.json(payload);
 });
 

--- a/src/cmsAdapt.js
+++ b/src/cmsAdapt.js
@@ -18,7 +18,6 @@ const cmsAdapter = {
     console.log(res)
     return res.json();
   },
-
   async fetchScreenings() {
     try {
       const response = await fetch(`${API_BASE}/screenings?populate=movie`);
@@ -28,13 +27,12 @@ const cmsAdapter = {
       console.error('Error fetching screenings:', error);
       throw error;
     }
-
-
+  },
+  async fetchMovieScreenings(id) {
+    const response = await fetch(`${API_BASE}/screenings?filters[movie]=${id}`);
+    const payload = await response.json();
+    return payload;
   }
-
-
-
-
 }
 
 export default cmsAdapter;

--- a/tests/detailPageScreening.test.js
+++ b/tests/detailPageScreening.test.js
@@ -1,0 +1,22 @@
+import { afterEach } from 'node:test';
+import { jest } from '@jest/globals';
+import { movieScreening, dateHasPassed } from '../utils/screeningUtils';
+import { mockData } from './__mocks__/frontPageMockData.js'
+
+describe('detailPageScreening', () => {
+    afterEach(() => {
+        jest.clearAllTimers();
+    })
+    test('detail page should only show the upcoming screenings', async () => {
+        const mockAdapter = {fetchMovieScreenings: async _ => mockData};
+        const payload = await movieScreening("", mockAdapter); // vi behöver inte ID för vi har hårdkodat mockdata
+        payload.forEach(screening => {
+            const startTime = screening.attributes.start_time.slice(0, -8);
+            const startTimes = startTime.split("T");
+            expect(!dateHasPassed(new Date(startTimes[0]), startTimes[1])).toBeTruthy();
+        });
+    })
+});
+
+
+

--- a/utils/screeningUtils.js
+++ b/utils/screeningUtils.js
@@ -61,7 +61,7 @@ export async function movieScreening(id, adapter) {
         const startTime = screening.attributes.start_time.slice(0, -8);
         const startTimes = startTime.split("T");
         const dateNotPassed = !dateHasPassed(new Date(startTimes[0]), startTimes[1]);
-        return false;
+        return dateNotPassed;
     });
     return filteredData;
 }

--- a/utils/screeningUtils.js
+++ b/utils/screeningUtils.js
@@ -48,3 +48,21 @@ export async function frontpageScreening(adapter) {
     return maxScreenings
 }
 
+export function dateHasPassed(date, time) {
+    const hoursAndMinutes = time.split(":");
+    return (
+      date.setHours(hoursAndMinutes[0], hoursAndMinutes[1], 0, 0) <= Date.now()
+    );
+  }
+
+export async function movieScreening(id, adapter) {
+    const payload = await adapter.fetchMovieScreenings(id);
+    const filteredData = payload.data.filter(screening => {
+        const startTime = screening.attributes.start_time.slice(0, -8);
+        const startTimes = startTime.split("T");
+        const dateNotPassed = !dateHasPassed(new Date(startTimes[0]), startTimes[1]);
+        return false;
+    });
+    return filteredData;
+}
+


### PR DESCRIPTION
I moved the logic of filtering date and time to the server from the client. I also added a test that checks if the movie screening date has passed for the detail page

![Skärmbild 2024-02-09 124042](https://github.com/maxlin94/A5-Kino-Grupparbete/assets/144684431/1911316a-ef45-4d1b-a32d-701ccdd8d8ad)
